### PR TITLE
Remove prettyprint, use Gson setPrettyPrinting instead

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 apply plugin: 'jacoco'
 
 group 'co.tala.performance.flo'
-version '0.1.2'
+version '0.1.3'
 
 println "version:${version}"
 

--- a/src/test/groovy/co/tala/performance/async/ParallelsSpec.groovy
+++ b/src/test/groovy/co/tala/performance/async/ParallelsSpec.groovy
@@ -1,7 +1,6 @@
 package co.tala.performance.async
 
 import co.tala.performance.exception.AggregateException
-import org.codehaus.groovy.runtime.powerassert.PowerAssertionError
 import spock.lang.Specification
 
 class ParallelsSpec extends Specification {

--- a/src/test/groovy/co/tala/performance/flo/FloRunnaIntegrationSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/FloRunnaIntegrationSpec.groovy
@@ -1,7 +1,6 @@
 package co.tala.performance.flo
 
 import co.tala.performance.exception.AggregateException
-import org.codehaus.groovy.runtime.powerassert.PowerAssertionError
 import spock.lang.Specification
 
 class FloRunnaIntegrationSpec extends Specification {

--- a/src/test/groovy/co/tala/performance/flo/FloWriterSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/FloWriterSpec.groovy
@@ -3,7 +3,6 @@ package co.tala.performance.flo
 import co.tala.performance.converter.InstantConverter
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import groovy.json.JsonOutput
 import spock.lang.Specification
 
 import java.time.Instant
@@ -18,7 +17,10 @@ class FloWriterSpec extends Specification {
         floIOMock = Mock()
         settings = ModelFactory.createFloRunnaSettings()
         sut = new FloWriter(settings, floIOMock)
-        gson = new GsonBuilder().registerTypeAdapter(Instant.class, new InstantConverter()).create()
+        gson = new GsonBuilder()
+            .setPrettyPrinting()
+            .registerTypeAdapter(Instant.class, new InstantConverter())
+            .create()
     }
 
     def "it should initialize with default constructor"() {
@@ -97,7 +99,7 @@ class FloWriterSpec extends Specification {
     }
 
     private boolean assertJson(String content, FloExecutionResult result) {
-        assert content == JsonOutput.prettyPrint(gson.toJson(result))
+        assert content == gson.toJson(result)
         true
     }
 


### PR DESCRIPTION
- Switching to use GSON setPrettyPrinting() instead of JsonOutput
  prettyPrint() (to lesson memory footprint)
- Using withCloseable to close some file handles