### PR TITLE
pass closure for metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 apply plugin: 'jacoco'
 
 group 'co.tala.performance.flo'
-version '0.1.3'
+version '0.1.4'
 
 println "version:${version}"
 

--- a/src/main/groovy/co/tala/performance/flo/Flotility.groovy
+++ b/src/main/groovy/co/tala/performance/flo/Flotility.groovy
@@ -44,7 +44,7 @@ class Flotility<T> implements IFlotility<T> {
                 }
                 finally {
                     final Instant afterAction = now
-                    this.results.addResult(floStep, new FloStepResult(beforeAction, afterAction, workFlo.metadata, error, resultId))
+                    this.results.addResult(floStep, new FloStepResult(beforeAction, afterAction, workFlo.metadata(), error, resultId))
                 }
             }
         }
@@ -52,7 +52,7 @@ class Flotility<T> implements IFlotility<T> {
             final Instant afterWorkFlo = now
             this.results.addResult(
                 new FloStep(FloSource.TOTAL_SUMMARY, {}, Integer.MAX_VALUE),
-                new FloStepResult(beforeWorkFlo, afterWorkFlo, workFlo.metadata, error, resultId)
+                new FloStepResult(beforeWorkFlo, afterWorkFlo, workFlo.metadata(), error, resultId)
             )
         }
     }

--- a/src/main/groovy/co/tala/performance/flo/WorkFlo.groovy
+++ b/src/main/groovy/co/tala/performance/flo/WorkFlo.groovy
@@ -8,11 +8,19 @@ import groovy.transform.PackageScope
  */
 @PackageScope
 class WorkFlo<T> {
-    final T metadata
+    final Closure<T> metadata
     final List<FloStep> steps
 
     WorkFlo(
         T metadata,
+        List<FloStep> steps
+    ) {
+        this.metadata = { metadata }
+        this.steps = steps
+    }
+
+    WorkFlo(
+        Closure<T> metadata,
         List<FloStep> steps
     ) {
         this.metadata = metadata

--- a/src/main/groovy/co/tala/performance/flo/WorkFloBuilder.groovy
+++ b/src/main/groovy/co/tala/performance/flo/WorkFloBuilder.groovy
@@ -6,7 +6,7 @@ package co.tala.performance.flo
  */
 class WorkFloBuilder<T> {
     private final List<FloStep> floSteps
-    private T metadata
+    private Closure<T> metadata
     private int count
 
     WorkFloBuilder() {
@@ -15,11 +15,22 @@ class WorkFloBuilder<T> {
     }
 
     /**
-     * Sets the generic metadata for a [WorkFlo]
+     * Sets the generic metadata for a [WorkFlo]. Value is realized before the [WorkFlo] execution begins.
      * @param metadata
      * @return
      */
+    @Deprecated
     WorkFloBuilder setMetadata(T metadata) {
+        this.metadata = { metadata }
+        this
+    }
+
+    /**
+     * Sets the generic metadata for a [WorkFlo]. Value will be realized after [WorkFlo] is executed.
+     * @param metadata
+     * @return
+     */
+    WorkFloBuilder setMetadata(Closure<T> metadata) {
         this.metadata = metadata
         this
     }

--- a/src/test/groovy/co/tala/performance/flo/FloRunnaIntegrationSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/FloRunnaIntegrationSpec.groovy
@@ -5,11 +5,11 @@ import spock.lang.Specification
 
 class FloRunnaIntegrationSpec extends Specification {
     private Random random
-    private Object metadata
+    private Closure<Object> metadata
 
     def setup() {
         random = new Random()
-        metadata = [resourceId: UUID.randomUUID().toString(), map: [innerId: nextLong(), flo: "runna"]]
+        metadata = { [resourceId: UUID.randomUUID().toString(), map: [innerId: nextLong(), flo: "runna"]] }
     }
 
     def "flo runna integration spec"() {
@@ -17,26 +17,25 @@ class FloRunnaIntegrationSpec extends Specification {
             FloRunna floRunna = new FloRunna(new FloRunnaSettings(8, 3000, 1000, "Flo Runna Integration Test"))
 
         when: "flo runna is executed with 5 steps, each with various execution times, and some randomly throw exceptions"
-            Map<String, FloExecutionResult> results = floRunna.execute { WorkFloBuilder workFloBuilder ->
-
+            floRunna.execute { WorkFloBuilder workFloBuilder ->
                 workFloBuilder
-                        .setMetadata(metadata)
-                        .addStep("very fast step") {
-                            sleepFor(10, 30)
-                        }
-                        .addStep("fast step") {
-                            sleepFor(50, 200)
-                        }
-                        .addStep("medium step") {
-                            sleepFor(250, 500)
-                        }
-                        .addStep("slow step") {
-                            sleepFor(500, 1000)
-                        }
-                        .addStep("very slow step") {
-                            sleepFor(1000, 2000)
-                        }
-                        .build()
+                    .setMetadata(metadata)
+                    .addStep("very fast step") {
+                        sleepFor(10, 30)
+                    }
+                    .addStep("fast step") {
+                        sleepFor(50, 200)
+                    }
+                    .addStep("medium step") {
+                        sleepFor(250, 500)
+                    }
+                    .addStep("slow step") {
+                        sleepFor(500, 1000)
+                    }
+                    .addStep("very slow step") {
+                        sleepFor(1000, 2000)
+                    }
+                    .build()
             }
 
         then: "an AggregateException should be thrown"
@@ -48,19 +47,19 @@ class FloRunnaIntegrationSpec extends Specification {
             FloRunna floRunna = new FloRunna(new FloRunnaSettings(8, 3000, 1000, "Flo Runna Repeat Step Test"))
 
         when: "flo runna is executed with 5 steps, each with various execution times, and some randomly throw exceptions"
-            Map<String, FloExecutionResult> results = floRunna.execute { WorkFloBuilder workFloBuilder ->
+            floRunna.execute { WorkFloBuilder workFloBuilder ->
                 workFloBuilder
-                        .setMetadata(metadata)
-                        .addStep("repeat step") {
-                            sleepFor(10, 30)
-                        }
-                        .addStep("non repeat step") {
-                            sleepFor(50, 200)
-                        }
-                        .addStep("repeat step") {
-                            sleepFor(10, 30)
-                        }
-                        .build()
+                    .setMetadata(metadata)
+                    .addStep("repeat step") {
+                        sleepFor(10, 30)
+                    }
+                    .addStep("non repeat step") {
+                        sleepFor(50, 200)
+                    }
+                    .addStep("repeat step") {
+                        sleepFor(10, 30)
+                    }
+                    .build()
             }
 
         then: "an AggregateException should be thrown"

--- a/src/test/groovy/co/tala/performance/flo/WorkFloBuilderSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/WorkFloBuilderSpec.groovy
@@ -5,6 +5,33 @@ import spock.lang.Specification
 class WorkFloBuilderSpec extends Specification {
     def "build should create a WorkFlo"() {
         given: "WorkFloBuilder is initialized"
+            Closure<LinkedHashMap<String, String>> metadata = { ["foo": "bar"] }
+            Closure action = {}
+            WorkFloBuilder sut = new WorkFloBuilder()
+
+        when: "addStep is called 10 times"
+            sut.setMetadata(metadata)
+            10.times {
+                sut.addStep("step$it", action)
+            }
+
+        and: "build is invoked"
+            WorkFlo result = sut.build()
+
+        then: "a WorkFlo with 10 steps should be returned"
+            verifyAll(result) {
+                it.metadata() == metadata()
+                it.steps.size() == 10
+                it.steps.eachWithIndex { FloStep entry, int i ->
+                    assert entry.orderNumber == i
+                    assert entry.action == action
+                    assert entry.name == "step$i"
+                }
+            }
+    }
+
+    def "build should create a WorkFlo without Closure"() {
+        given: "WorkFloBuilder is initialized"
             LinkedHashMap<String, String> metadata = ["foo": "bar"]
             Closure action = {}
             WorkFloBuilder sut = new WorkFloBuilder()
@@ -20,7 +47,7 @@ class WorkFloBuilderSpec extends Specification {
 
         then: "a WorkFlo with 10 steps should be returned"
             verifyAll(result) {
-                it.metadata == metadata
+                it.metadata() == metadata
                 it.steps.size() == 10
                 it.steps.eachWithIndex { FloStep entry, int i ->
                     assert entry.orderNumber == i
@@ -32,7 +59,7 @@ class WorkFloBuilderSpec extends Specification {
 
     def "build with no steps should create an empty WorkFlo"() {
         given:
-            LinkedHashMap<String, String> metadata = ["foo": "bar"]
+            Closure<LinkedHashMap<String, String>> metadata = { ["foo": "bar"] }
             WorkFloBuilder sut = new WorkFloBuilder()
 
         when: "addStep is never called"
@@ -41,7 +68,7 @@ class WorkFloBuilderSpec extends Specification {
 
         then: "A WorkFlo with no steps should be returned"
             verifyAll(result) {
-                it.metadata == metadata
+                it.metadata() == metadata()
                 it.steps.size() == 0
             }
     }
@@ -57,7 +84,7 @@ class WorkFloBuilderSpec extends Specification {
         then: "A WorkFlo with no steps should be returned"
             verifyAll(result) {
                 it.steps.size() == 1
-                it.metadata == null
+                it.metadata() == null
             }
     }
 }

--- a/src/test/groovy/co/tala/performance/flo/WorkFloSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/WorkFloSpec.groovy
@@ -5,6 +5,29 @@ import spock.lang.Specification
 class WorkFloSpec extends Specification {
     def "WorkFlo should initialize"() {
         given:
+            Closure<LinkedHashMap<String, String>> metadata = { ["foo": "bar"] }
+            List<FloStep> floSteps = []
+            Closure action = {}
+            10.times {
+                floSteps.add(new FloStep("step$it", action, it))
+            }
+
+        when: "WorkFlo is initialized"
+            WorkFlo result = new WorkFlo(metadata, floSteps)
+
+        then: "it should not be null"
+            verifyAll(result) {
+                it.metadata() == metadata()
+                it.steps.eachWithIndex { FloStep entry, int i ->
+                    assert entry.name == floSteps[i].name
+                    assert entry.orderNumber == floSteps[i].orderNumber
+                    assert entry.action == action
+                }
+            }
+    }
+
+    def "WorkFlo should initialize 2"() {
+        given:
             LinkedHashMap<String, String> metadata = ["foo": "bar"]
             List<FloStep> floSteps = []
             Closure action = {}
@@ -17,7 +40,7 @@ class WorkFloSpec extends Specification {
 
         then: "it should not be null"
             verifyAll(result) {
-                it.metadata == metadata
+                it.metadata() == metadata
                 it.steps.eachWithIndex { FloStep entry, int i ->
                     assert entry.name == floSteps[i].name
                     assert entry.orderNumber == floSteps[i].orderNumber


### PR DESCRIPTION
Passing a Closure for metadata allows for the value to be realized after the workflo is executed. A use case for this is when we want to put some values from the execution of the test (i.e an api response) in the metadata. Otherwise, we are limited to setting only data from before the test begins.