### PR TITLE
allow output to be disabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 apply plugin: 'jacoco'
 
 group 'co.tala.performance.flo'
-version '0.1.4'
+version '0.1.5'
 
 println "version:${version}"
 

--- a/src/main/groovy/co/tala/performance/flo/FloRunna.groovy
+++ b/src/main/groovy/co/tala/performance/flo/FloRunna.groovy
@@ -71,7 +71,9 @@ class FloRunna<T> {
         finally {
             final Instant endTime = now
             results = flotility.results.toFloExecutionResults(startTime, endTime)
-            floWriter.writeResults(results)
+            if (settings.outputEnabled) {
+                floWriter.writeResults(results)
+            }
         }
         results
     }

--- a/src/main/groovy/co/tala/performance/flo/FloRunnaSettings.groovy
+++ b/src/main/groovy/co/tala/performance/flo/FloRunnaSettings.groovy
@@ -8,6 +8,7 @@ class FloRunnaSettings {
     final long duration
     final long rampup
     final String testName
+    final boolean outputEnabled
 
     FloRunnaSettings(
         int threads,
@@ -19,6 +20,21 @@ class FloRunnaSettings {
         this.duration = duration
         this.rampup = rampup
         this.testName = testName
+        this.outputEnabled = true
+    }
+
+    FloRunnaSettings(
+        int threads,
+        long duration,
+        long rampup,
+        String testName,
+        boolean outputEnabled
+    ) {
+        this.threads = threads
+        this.duration = duration
+        this.rampup = rampup
+        this.testName = testName
+        this.outputEnabled = outputEnabled
     }
 
     FloRunnaSettings(
@@ -35,6 +51,7 @@ class FloRunnaSettings {
         this.threads = getPropValue("threads", defaultThreads).toInteger()
         this.duration = getPropValue("duration", defaultDuration).toLong()
         this.rampup = getPropValue("rampup", defaultRampup).toLong()
+        this.outputEnabled = getPropValue("outputEnabled", "true").toBoolean()
         this.testName = testName
     }
 }

--- a/src/main/groovy/co/tala/performance/flo/FloStepResultStorage.groovy
+++ b/src/main/groovy/co/tala/performance/flo/FloStepResultStorage.groovy
@@ -29,9 +29,11 @@ class FloStepResultStorage<T> implements IFloStepResultStorage<T> {
     @Override
     @Synchronized("addResultLock")
     void addResult(FloStep floStep, FloStepResult<T> result) {
-        if (!map.containsKey(floStep.name))
-            map[floStep.name] = new FloStepResults<T>(floStep.orderNumber)
-        map[floStep.name].results << result
+        if (settings.outputEnabled) {
+            if (!map.containsKey(floStep.name))
+                map[floStep.name] = new FloStepResults<T>(floStep.orderNumber)
+            map[floStep.name].results << result
+        }
     }
 
     /**

--- a/src/test/groovy/co/tala/performance/flo/FloRunnaSettingsSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/FloRunnaSettingsSpec.groovy
@@ -16,6 +16,7 @@ class FloRunnaSettingsSpec extends Specification {
                 it.duration == 8000
                 it.rampup == 1000
                 it.testName == testName
+                it.outputEnabled
             }
     }
 
@@ -24,6 +25,7 @@ class FloRunnaSettingsSpec extends Specification {
             System.setProperty("threads", "1")
             System.setProperty("duration", "2")
             System.setProperty("rampup", "3")
+            System.setProperty("outputEnabled", "false")
             String testName = "testName"
 
         when: "FloRunnaSettings is initialized"
@@ -35,6 +37,7 @@ class FloRunnaSettingsSpec extends Specification {
                 it.duration == 2
                 it.rampup == 3
                 it.testName == testName
+                !it.outputEnabled
             }
     }
 
@@ -54,6 +57,26 @@ class FloRunnaSettingsSpec extends Specification {
                 it.duration == duration
                 it.rampup == rampup
                 it.testName == testName
+            }
+    }
+
+    def "FloRunnaSettings should initialize with override settings 2"() {
+        given: "threads, duration, and rampup are set"
+            int threads = 2
+            long duration = 4
+            long rampup = 6
+            String testName = "testName"
+
+        when: "FloRunnaSettings is initialized"
+            FloRunnaSettings result = new FloRunnaSettings(threads, duration, rampup, testName, false)
+
+        then: "the threads, duration, and rampup should be equal to the constructor overrides"
+            verifyAll(result) {
+                it.threads == threads
+                it.duration == duration
+                it.rampup == rampup
+                it.testName == testName
+                !it.outputEnabled
             }
     }
 }


### PR DESCRIPTION
- Long running soak tests may pose performance issues within Flo Runna. Disabling the output allows to run Flo Runna, and using instrumental tools such as Instana will provide metrics.