### PR TITLE
fix scenario where system property null or empty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 apply plugin: 'jacoco'
 
 group 'co.tala.performance.flo'
-version '0.1.5'
+version '0.1.6'
 
 println "version:${version}"
 

--- a/src/main/groovy/co/tala/performance/flo/FloRunnaSettings.groovy
+++ b/src/main/groovy/co/tala/performance/flo/FloRunnaSettings.groovy
@@ -41,7 +41,9 @@ class FloRunnaSettings {
         String testName
     ) {
         def getPropValue = { String key, Object defaultValue ->
-            System.getProperty(key, defaultValue.toString())
+            Optional.of(System.getProperty(key, defaultValue.toString()))
+                .filter({ value -> value != null && !value.isEmpty() })
+                .orElse(defaultValue as String)
         }
 
         int defaultThreads = 8

--- a/src/test/groovy/co/tala/performance/flo/FloRunnaSettingsSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/FloRunnaSettingsSpec.groovy
@@ -79,4 +79,25 @@ class FloRunnaSettingsSpec extends Specification {
                 !it.outputEnabled
             }
     }
+
+    def "FloRunnaSettings should handle cases where System property might be empty or null"() {
+        given: "if the System has set a property to empty string"
+            System.setProperty("threads", "")
+            System.setProperty("outputEnabled", "")
+            System.clearProperty("duration") // You can't set a property to have null value, so clear
+            System.clearProperty("rampup")
+            String testName = "testName"
+
+        when: "FloRunnaSettings is initialized"
+            FloRunnaSettings result = new FloRunnaSettings(testName)
+
+        then: "the threads, duration, and rampup should be equal to the constructor overrides (values from FloRunnaSettings class)"
+            verifyAll(result) {
+                it.threads == 8
+                it.duration == 8000
+                it.rampup == 1000
+                it.testName == testName
+                it.outputEnabled
+            }
+    }
 }


### PR DESCRIPTION
When running sample performance test, my system happen to have `threads` set to empty.

![Screen Shot 2020-12-03 at 3 32 02 PM](https://user-images.githubusercontent.com/61523529/101104399-dffdc100-357f-11eb-8fbe-c2ccc3c9f4fb.png)

Since empty value returned, call to `toInteger()` fails.

<img width="1347" alt="Screen Shot 2020-12-03 at 3 44 49 PM" src="https://user-images.githubusercontent.com/61523529/101104475-0cb1d880-3580-11eb-97db-47d043292736.png">

Adjusting so that if value for System property ends up null or empty, use the `defaultValue` provided.

<img width="1105" alt="Screen Shot 2020-12-03 at 3 45 05 PM" src="https://user-images.githubusercontent.com/61523529/101104522-2a7f3d80-3580-11eb-8834-6a6f9ee2e2a0.png">

![image](https://user-images.githubusercontent.com/61523529/101104606-569abe80-3580-11eb-86f7-553048bbd858.png)
