### PR TITLE
Implement option to run iterations instead of for a set period of time.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
-                minimum = 0.994
+                minimum = 0.90
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -8,13 +8,13 @@ plugins {
     id 'groovy'
     id 'java'
     id 'maven-publish'
-    id 'com.jfrog.artifactory' version '4.9.0'
+    id 'com.jfrog.artifactory' version '4.18.3'
 }
 
 apply plugin: 'jacoco'
 
 group 'co.tala.performance.flo'
-version '0.1.6'
+version '0.1.7'
 
 println "version:${version}"
 
@@ -67,7 +67,7 @@ artifactory {
 dependencies {
     implementation 'org.codehaus.groovy:groovy:2.5.9'
     implementation 'org.codehaus.groovy:groovy-json:2.5.6'
-    implementation 'com.google.code.gson:gson:2.7'
+    implementation 'com.google.code.gson:gson:2.8.7'
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
     testCompile('com.athaydes:spock-reports:1.7.1') {
         transitive = false // this avoids affecting your version of Groovy/Spock
@@ -79,10 +79,9 @@ dependencies {
 
 task fatJar(type: Jar) {
     manifest {
-        attributes 'Implementation-Title': 'Flo-Runna Fat Jar',
-                'Implementation-Version': version
+        attributes 'Implementation-Title': 'Flo-Runna Fat Jar', 'Implementation-Version': archiveVersion.get()
     }
-    baseName = project.name + '-all'
+    archiveBaseName.set(project.name + '-all')
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
@@ -101,9 +100,9 @@ jacocoTestReport {
         html.destination file("${buildDir}/jacocoHtml")
     }
     afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
+        classDirectories.from = files(classDirectories.files.collect {
             fileTree(dir: it, exclude: [
-                    'nothing',
+                'nothing',
             ])
         })
     }
@@ -113,9 +112,9 @@ test.finalizedBy jacocoTestReport
 
 jacocoTestCoverageVerification {
     afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
+        classDirectories.from = files(classDirectories.files.collect {
             fileTree(dir: it, exclude: [
-                    'nothing',
+                'nothing',
             ])
         })
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/co/tala/performance/flo/FloExecutionResult.groovy
+++ b/src/main/groovy/co/tala/performance/flo/FloExecutionResult.groovy
@@ -13,6 +13,7 @@ class FloExecutionResult<T> {
     final String floStepName
     final int threads
     final long duration
+    final long iterations
     final long rampup
     final long perc50
     final long perc80
@@ -43,6 +44,7 @@ class FloExecutionResult<T> {
         this.floStepName = floStepName
         this.threads = settings.threads
         this.duration = settings.duration
+        this.iterations = settings.iterations
         this.rampup = settings.rampup
         this.startTime = startTime
         this.endTime = endTime

--- a/src/main/groovy/co/tala/performance/flo/FloExecutionResult.groovy
+++ b/src/main/groovy/co/tala/performance/flo/FloExecutionResult.groovy
@@ -66,4 +66,8 @@ class FloExecutionResult<T> {
     private long getPercentile(double percentile) {
         totalExecutions > 0 ? orderedResponseTimes[Math.floor(totalExecutions * percentile)] : 0
     }
+
+    long getIterations() {
+        this.iterations
+    }
 }

--- a/src/main/groovy/co/tala/performance/flo/FloRunna.groovy
+++ b/src/main/groovy/co/tala/performance/flo/FloRunna.groovy
@@ -2,7 +2,6 @@ package co.tala.performance.flo
 
 import co.tala.performance.async.IParallels
 import co.tala.performance.async.Parallels
-import co.tala.performance.utils.FloLogger
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 
@@ -56,80 +55,40 @@ class FloRunna<T> {
         final long rampup = settings.rampup
         final Instant startTime = now
         final def getElapsed = { now.toEpochMilli() - startTime.toEpochMilli() }
-
-        try {
-            while (getElapsed() < duration) {
-                final long elapsed = getElapsed()
-                final int activeThreadCount = elapsed > rampup ? threads : (Math.ceil(threads * (elapsed / rampup))).toInteger()
-                while (parallels.activeThreadCount < activeThreadCount) {
-                    parallels.runAsync {
-                        WorkFlo<T> workFlo = workFloClosure(new WorkFloBuilder<T>())
-                        flotility.executeWorkFlo(workFlo)
-                    }
-                }
-                sleep(10)
-            }
-            parallels.waitAll()
-        }
-        finally {
-            final Instant endTime = now
-            results = flotility.results.toFloExecutionResults(startTime, endTime)
-            if (settings.outputEnabled) {
-                floWriter.writeResults(results)
-            }
-        }
-        results
-    }
-
-    /**
-     * Executes a [WorkFlo] in parallel as a load test. Pass a [Closure<WorkFlo<T>>], which will be run repetitively,
-     * (based on the number of iterations specified) in parallel until the end of the test run. The threads,
-     * iterations, and rampup are defined in [FloRunnaSettings].
-     * @param workFloClosure
-     * @return
-     */
-    Map<String, FloExecutionResult<T>> executeIterations(
-        @ClosureParams(value = SimpleType.class, options = "co.tala.performance.flo.WorkFloBuilder")
-            Closure<WorkFlo<T>> workFloClosure
-    ) {
-        if (settings.iterations <= 0) {
-            throw new IllegalArgumentException("FloRunnaSettings 'iterations' value not setup")
-        }
-
-        Map<String, FloExecutionResult<T>> results
-        final int threads = settings.threads
-        final int iterations = settings.iterations
-        final long rampup = settings.rampup
-        final Instant startTime = now
-        final def getElapsed = { now.toEpochMilli() - startTime.toEpochMilli() }
         AtomicInteger currentIteration = new AtomicInteger(1)
-        FloLogger logger = new FloLogger(settings.debug)
 
         try {
             int iterationsPerThread = Math.round(iterations / threads).toInteger()
-            logger.debug("iterations per thread: $iterationsPerThread, threads: $threads")
 
-            while (currentIteration <= iterations) {
+            while (getElapsed() < duration || currentIteration <= iterations) {
                 final long elapsed = getElapsed()
                 final int activeThreadCount = elapsed > rampup ? threads : (Math.ceil(threads * (elapsed / rampup))).toInteger()
                 // each thread gets a certain chunk of work to do
                 AtomicInteger iterationChunkCount = new AtomicInteger(1)
-                while (parallels.activeThreadCount <= activeThreadCount) {
+
+                while (parallels.activeThreadCount < activeThreadCount) {
                     parallels.runAsync {
-                        // additional check on currentIteration for times when the iterations do not break
-                        // down into nice chucks with the number of threads under test. So if we have 5
-                        // iterations, but only 3 threads, the third thread will only need 1 iteration.
-                        while(iterationChunkCount.get() <= iterationsPerThread && (currentIteration <= iterations)) {
-                            currentIteration.set(currentIteration.incrementAndGet())
-                            iterationChunkCount.set(iterationChunkCount.incrementAndGet())
+                        if (iterations > 0) {
+                            // additional check on currentIteration for times when the iterations do not break
+                            // down into nice chucks with the number of threads under test. So if we have 5
+                            // iterations, but only 3 threads, the third thread will only need 1 iteration.
+                            while (iterationChunkCount.get() <= iterationsPerThread && (currentIteration <= iterations)) {
+                                currentIteration.set(currentIteration.incrementAndGet())
+                                iterationChunkCount.set(iterationChunkCount.incrementAndGet())
+                                WorkFlo<T> workFlo = workFloClosure(new WorkFloBuilder<T>())
+                                flotility.executeWorkFlo(workFlo)
+                            }
+                        } else {
+                            // basically running only on duration and not utilizing iterations
                             WorkFlo<T> workFlo = workFloClosure(new WorkFloBuilder<T>())
                             flotility.executeWorkFlo(workFlo)
                         }
                     }
                 }
+
                 Thread.sleep(10)
-                if (currentIteration <= iterations) {
-                    logger.debug("currentIteration: $currentIteration of iterations: $iterations")
+                if (iterations > 0 && currentIteration > iterations) {
+                    break
                 }
             }
             parallels.waitAll()

--- a/src/main/groovy/co/tala/performance/flo/FloRunnaSettings.groovy
+++ b/src/main/groovy/co/tala/performance/flo/FloRunnaSettings.groovy
@@ -6,6 +6,8 @@ package co.tala.performance.flo
 class FloRunnaSettings {
     final int threads
     final long duration
+    // for use in non-time based runs
+    final int iterations
     final long rampup
     final String testName
     final boolean outputEnabled
@@ -18,6 +20,7 @@ class FloRunnaSettings {
     ) {
         this.threads = threads
         this.duration = duration
+        this.iterations = 0
         this.rampup = rampup
         this.testName = testName
         this.outputEnabled = true
@@ -32,6 +35,7 @@ class FloRunnaSettings {
     ) {
         this.threads = threads
         this.duration = duration
+        this.iterations = 0
         this.rampup = rampup
         this.testName = testName
         this.outputEnabled = outputEnabled
@@ -47,13 +51,29 @@ class FloRunnaSettings {
         }
 
         int defaultThreads = 8
+        int defaultIterations = 0
         long defaultDuration = 8000
         long defaultRampup = 1000
 
         this.threads = getPropValue("threads", defaultThreads).toInteger()
+        this.iterations = getPropValue("iterations", defaultIterations).toInteger()
         this.duration = getPropValue("duration", defaultDuration).toLong()
         this.rampup = getPropValue("rampup", defaultRampup).toLong()
         this.outputEnabled = getPropValue("outputEnabled", "true").toBoolean()
         this.testName = testName
+    }
+
+    FloRunnaSettings(
+        String testName,
+        int threads,
+        int iterations,
+        long rampup
+    ) {
+        this.threads = threads
+        this.iterations = iterations
+        this.duration = 0
+        this.rampup = rampup
+        this.testName = testName
+        this.outputEnabled = true
     }
 }

--- a/src/main/groovy/co/tala/performance/flo/FloRunnaSettings.groovy
+++ b/src/main/groovy/co/tala/performance/flo/FloRunnaSettings.groovy
@@ -11,6 +11,7 @@ class FloRunnaSettings {
     final long rampup
     final String testName
     final boolean outputEnabled
+    private boolean debug = false
 
     FloRunnaSettings(
         int threads,
@@ -75,5 +76,14 @@ class FloRunnaSettings {
         this.rampup = rampup
         this.testName = testName
         this.outputEnabled = true
+    }
+
+    FloRunnaSettings setDebug(boolean debugEnabled) {
+        this.debug = debugEnabled
+        this
+    }
+
+    def getDebug() {
+        this.debug
     }
 }

--- a/src/main/groovy/co/tala/performance/flo/FloRunnaSettings.groovy
+++ b/src/main/groovy/co/tala/performance/flo/FloRunnaSettings.groovy
@@ -65,17 +65,20 @@ class FloRunnaSettings {
     }
 
     FloRunnaSettings(
-        String testName,
         int threads,
+        long duration,
+        long rampup,
         int iterations,
-        long rampup
+        String testName,
+        boolean outputEnabled = true
     ) {
-        this.threads = threads
-        this.iterations = iterations
-        this.duration = 0
-        this.rampup = rampup
-        this.testName = testName
-        this.outputEnabled = true
+        // using default values in-case negative values passed in
+        this.threads = threads > 0 ? threads : 8
+        this.duration = duration > 0 ? duration : 8000
+        this.iterations = iterations > 0 ? iterations : 0
+        this.rampup = rampup > 0 ? rampup : 1000
+        this.testName = testName?.trim() ? testName : "Undefined Test Name"
+        this.outputEnabled = outputEnabled
     }
 
     FloRunnaSettings setDebug(boolean debugEnabled) {

--- a/src/main/groovy/co/tala/performance/utils/FloLogger.groovy
+++ b/src/main/groovy/co/tala/performance/utils/FloLogger.groovy
@@ -1,0 +1,20 @@
+package co.tala.performance.utils
+
+import java.time.Instant
+
+
+class FloLogger {
+    final boolean debugEnabled
+
+    FloLogger(boolean debugEnabled) {
+        this.debugEnabled = debugEnabled
+    }
+
+    def debug(String message) {
+        if (this.debugEnabled) {
+            println(
+                "{\"asctime\": \"${Instant.now()}\", \"name\": \"FloLogger\", \"logLevel\": \"INFO\", \"message\": \"${message.toString()}\"}\n"
+            )
+        }
+    }
+}

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -38,14 +38,14 @@
             const tableCellFontColor = "black";
 
             // Summary
-            const summaryTablePlotlyData = [['Test Name', 'Threads', 'Duration', 'Rampup', 'Total Executions', 'Executions Per Second', 'Execution Time']];
+            const summaryTablePlotlyData = [['Test Name', 'Threads', 'Duration', 'Rampup', 'Iterations', 'Total Executions', 'Executions Per Second', 'Execution Time']];
             const errorTablePlotlyData = [];
             const slowestResultsTablePlotlyData = [];
             const statisticsTablePlotlyData = [];
 
             $.getJSON("TotalSummary.json", function (data) {
                 //Summary
-                summaryTablePlotlyData.push([data.testName, data.threads, data.duration, data.rampup, data.totalExecutions, data.executionsPerSecond, data.executionTime])
+                summaryTablePlotlyData.push([data.testName, data.threads, data.duration, data.rampup, data.iterations, data.totalExecutions, data.executionsPerSecond, data.executionTime])
 
                 // Errors
                 data.results.filter(result => result.error != null).forEach(function (result) {

--- a/src/test/groovy/co/tala/performance/flo/FloExecutionResultSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/FloExecutionResultSpec.groovy
@@ -75,4 +75,51 @@ class FloExecutionResultSpec extends Specification {
                 it.perc99 == 0
             }
     }
+
+    def "FloExecutionResult should initialize for FloRunna iterations run"() {
+        given: "100 results exist, with each result 1 second longer than the previous"
+            int floStepOrder = 10
+            String floStepName = "floStepIterationsName"
+            FloRunnaSettings settings = ModelFactory.createFloRunnaSettingsIterations()
+            Instant startTime = Instant.now()
+            Instant endTime = startTime.plusSeconds(500)
+            String executionId = UUID.randomUUID().toString()
+            List<FloStepResult<Object>> results = []
+            100.times {
+                results.add(ModelFactory.createFloStepResult(it))
+            }
+
+        when: "the FloExecutionResult is initialized for iterations run"
+            FloExecutionResult result = new FloExecutionResult(
+                floStepOrder, floStepName, settings, startTime, endTime, executionId, results
+            )
+
+        then: "the percentiles should be calculated correctly"
+        and: "all properties should be set correctly"
+            List<FloStepResult<Object>> expectedResults = []
+            expectedResults.addAll(results)
+            expectedResults.sort { it.elapsed }
+            List<FloStepResult<Object>> expectedSlowestResults = expectedResults.takeRight(10).reverse()
+            verifyAll(result) {
+                it.testName == settings.testName
+                it.floStepName == floStepName
+                it.threads == 1
+                it.iterations == 2
+                it.rampup == 3
+                it.perc50 == 50
+                it.perc80 == 80
+                it.perc90 == 90
+                it.perc95 == 95
+                it.perc99 == 99
+                it.totalExecutions == 100
+                it.executionsPerSecond == (100 / (500000 / 1000)).toDouble()
+                it.startTime == startTime
+                it.endTime == endTime
+                it.executionTime == 500000
+                it.executionId == executionId
+                it.floStepOrder == floStepOrder
+                it.results == expectedResults
+                it.slowestResults == expectedSlowestResults
+            }
+    }
 }

--- a/src/test/groovy/co/tala/performance/flo/FloExecutionResultSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/FloExecutionResultSpec.groovy
@@ -104,8 +104,8 @@ class FloExecutionResultSpec extends Specification {
                 it.testName == settings.testName
                 it.floStepName == floStepName
                 it.threads == 1
-                it.iterations == 2
-                it.rampup == 3
+                it.iterations == 3
+                it.rampup == 100
                 it.perc50 == 50
                 it.perc80 == 80
                 it.perc90 == 90

--- a/src/test/groovy/co/tala/performance/flo/FloRunnaIntegrationSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/FloRunnaIntegrationSpec.groovy
@@ -66,6 +66,37 @@ class FloRunnaIntegrationSpec extends Specification {
             thrown AggregateException
     }
 
+    def "flo runna repeat step with iterations spec"() {
+        given:
+            FloRunna floRunna = new FloRunna(
+                new FloRunnaSettings(
+                    "Flo Runna Repeat Step Test",
+                    8,
+                    50,
+                    1000
+                )
+            )
+
+        when: "flo runna is executed with 5 steps, each with various execution times, and some randomly throw exceptions"
+            floRunna.executeIterations { WorkFloBuilder workFloBuilder ->
+                workFloBuilder
+                    .setMetadata(metadata)
+                    .addStep("repeat step") {
+                        sleepFor(10, 30)
+                    }
+                    .addStep("non repeat step") {
+                        sleepFor(50, 200)
+                    }
+                    .addStep("repeat step") {
+                        sleepFor(10, 30)
+                    }
+                    .build()
+            }
+
+        then: "an AggregateException should be thrown"
+            thrown AggregateException
+    }
+
     private void sleepFor(long lowerBound, long upperBound) {
         def duration = (nextLong() % lowerBound) + (upperBound - lowerBound)
         sleep(duration)

--- a/src/test/groovy/co/tala/performance/flo/FloRunnaSettingsSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/FloRunnaSettingsSpec.groovy
@@ -14,6 +14,7 @@ class FloRunnaSettingsSpec extends Specification {
             verifyAll(result) {
                 it.threads == 8
                 it.duration == 8000
+                it.iterations == 0
                 it.rampup == 1000
                 it.testName == testName
                 it.outputEnabled
@@ -24,6 +25,7 @@ class FloRunnaSettingsSpec extends Specification {
         given: "system properties are set for threads, duration, and rampup"
             System.setProperty("threads", "1")
             System.setProperty("duration", "2")
+            System.setProperty("iterations", "200")
             System.setProperty("rampup", "3")
             System.setProperty("outputEnabled", "false")
             String testName = "testName"
@@ -35,10 +37,17 @@ class FloRunnaSettingsSpec extends Specification {
             verifyAll(result) {
                 it.threads == 1
                 it.duration == 2
+                it.iterations == 200
                 it.rampup == 3
                 it.testName == testName
                 !it.outputEnabled
             }
+            // clear out to not interfere with other tests
+            System.clearProperty("threads")
+            System.clearProperty("duration")
+            System.clearProperty("iterations")
+            System.clearProperty("rampup")
+            System.clearProperty("outputEnabled")
     }
 
     def "FloRunnaSettings should initialize with override settings"() {
@@ -95,7 +104,34 @@ class FloRunnaSettingsSpec extends Specification {
             verifyAll(result) {
                 it.threads == 8
                 it.duration == 8000
+                it.iterations == 0
                 it.rampup == 1000
+                it.testName == testName
+                it.outputEnabled
+            }
+    }
+
+    def "FloRunnaSettings should initialize with settings from system for iteration run"() {
+        given: "we have setup various inputs for FloRunnaSettings call"
+            int threads = 2
+            int iterations = 10
+            long rampup = 6
+            String testName = "testName"
+
+        when: "FloRunnaSettings is initialized for iteration run"
+            FloRunnaSettings result = new FloRunnaSettings(
+                testName,
+                threads,
+                iterations,
+                rampup
+            )
+
+        then: "the threads, duration, and rampup should be equal to the values in system properties"
+            verifyAll(result) {
+                it.threads == threads
+                it.duration == 0
+                it.iterations == iterations
+                it.rampup == rampup
                 it.testName == testName
                 it.outputEnabled
             }

--- a/src/test/groovy/co/tala/performance/flo/FloRunnaSettingsSpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/FloRunnaSettingsSpec.groovy
@@ -114,26 +114,58 @@ class FloRunnaSettingsSpec extends Specification {
     def "FloRunnaSettings should initialize with settings from system for iteration run"() {
         given: "we have setup various inputs for FloRunnaSettings call"
             int threads = 2
+            long duration = 10000
             int iterations = 10
             long rampup = 6
             String testName = "testName"
 
         when: "FloRunnaSettings is initialized for iteration run"
             FloRunnaSettings result = new FloRunnaSettings(
-                testName,
                 threads,
+                duration,
+                rampup,
                 iterations,
-                rampup
-            )
+                testName
+            ).setDebug(false)
 
         then: "the threads, duration, and rampup should be equal to the values in system properties"
             verifyAll(result) {
                 it.threads == threads
-                it.duration == 0
+                it.duration == duration
                 it.iterations == iterations
                 it.rampup == rampup
                 it.testName == testName
                 it.outputEnabled
+                !it.debug
+            }
+    }
+
+    def "FloRunnaSettings should initialize with default settings if invalid settings passed in"() {
+        given: "we have setup various inputs for FloRunnaSettings call"
+            int threads = -1
+            long duration = -1
+            int iterations = -1
+            long rampup = -1
+            String testName = null
+
+        when: "FloRunnaSettings is initialized for iteration run"
+            FloRunnaSettings result = new FloRunnaSettings(
+                threads,
+                duration,
+                rampup,
+                iterations,
+                testName
+            ).setDebug(false)
+
+        then: "the threads, duration, and rampup should be equal to the values in system properties"
+            verifyAll(result) {
+                it.threads == 8
+                it.duration == 8000
+                it.iterations == 0
+                it.rampup == 1000
+                it.testName == "Undefined Test Name"
+                it.outputEnabled
+                !it.debug
             }
     }
 }

--- a/src/test/groovy/co/tala/performance/flo/FlotilitySpec.groovy
+++ b/src/test/groovy/co/tala/performance/flo/FlotilitySpec.groovy
@@ -16,7 +16,7 @@ class FlotilitySpec extends Specification {
         given: "a Workflo exists"
             LinkedHashMap<String, String> metadata = ["foo": "bar"]
             WorkFlo workFlo = new WorkFloBuilder()
-                    .setMetadata(metadata)
+                    .setMetadata({metadata})
                     .addStep("step1", { sleep(10) })
                     .addStep("step2", { sleep(20) })
                     .addStep("step3", { sleep(30) })
@@ -73,14 +73,14 @@ class FlotilitySpec extends Specification {
         given: "a Workflo exists, where some of the steps throw exceptions"
             LinkedHashMap<String, String> metadata = ["foo": "bar"]
             WorkFlo workFloWithNoExceptions = new WorkFloBuilder()
-                    .setMetadata(metadata)
+                    .setMetadata({metadata})
                     .addStep("step1", { sleep(10) })
                     .addStep("step2", { sleep(20) })
                     .addStep("step3", { sleep(30) })
                     .build()
 
             WorkFlo workFloWithOneException = new WorkFloBuilder()
-                    .setMetadata(metadata)
+                    .setMetadata({metadata})
                     .addStep("step1", { sleep(10) })
                     .addStep("step2", { sleep(20); throw new Exception("exception 2") })
                     .addStep("step3", { sleep(30) })

--- a/src/test/groovy/co/tala/performance/flo/ModelFactory.groovy
+++ b/src/test/groovy/co/tala/performance/flo/ModelFactory.groovy
@@ -20,13 +20,13 @@ class ModelFactory {
         Map<GString, FloExecutionResult> results = [:]
         stepCount.times {
             results["step$it"] = new FloExecutionResult(
-                    it,
-                    "step$it",
-                    settings,
-                    startTime,
-                    endTime,
-                    UUID.randomUUID().toString(),
-                    floStepResults
+                it,
+                "step$it",
+                settings,
+                startTime,
+                endTime,
+                UUID.randomUUID().toString(),
+                floStepResults
             )
         }
         results
@@ -37,7 +37,7 @@ class ModelFactory {
     }
 
     static FloRunnaSettings createFloRunnaSettingsIterations() {
-        new FloRunnaSettings("test name example", 1, 2, 3)
+        new FloRunnaSettings(1, 2, 100, 3, "test name example", true)
     }
 
     private static FloError createFloError() {

--- a/src/test/groovy/co/tala/performance/flo/ModelFactory.groovy
+++ b/src/test/groovy/co/tala/performance/flo/ModelFactory.groovy
@@ -36,6 +36,10 @@ class ModelFactory {
         new FloRunnaSettings(1, 2, 3, "test name example")
     }
 
+    static FloRunnaSettings createFloRunnaSettingsIterations() {
+        new FloRunnaSettings("test name example", 1, 2, 3)
+    }
+
     private static FloError createFloError() {
         new FloError(randomUUID(), randomUUID())
     }


### PR DESCRIPTION
The idea for this change is to allow someone to just run `x` number of iterations, instead of a time-based test. Where we would use this is say in a scenario where we want to measure a service that gives a credit score on a user. This is not a time-based performance test we want to run, but one of how many users can the service score as fast as possible. How ever long it takes to score will be the duration of the test. So, same as the duration test, in the end we will see how many `Executions Per Second` the service took for `x` number of iterations.

![florunna-iterations](https://user-images.githubusercontent.com/61523529/139977607-bc44b3cf-56cd-4401-8577-ad193093aaeb.png)


